### PR TITLE
[CD] Fix Invalid Backend Input Errors Not Showing on Register Page

### DIFF
--- a/client/src/pages/register/index.tsx
+++ b/client/src/pages/register/index.tsx
@@ -85,12 +85,12 @@ const RegisterPage = (): JSX.Element => {
       if (axios.isAxiosError(err)) {
         const { response } = err as AxiosError;
         const errors = (response as any).data.errors;
-        const emailFieldErrors = errors.filter((error: any) => error.param === 'email').map((error: any) => error.msg);
+        const emailFieldErrors = errors.filter((error: any) => error.path === 'email').map((error: any) => error.msg);
         const password1FieldErrors = errors
-          .filter((error: any) => error.param === 'password1')
+          .filter((error: any) => error.path === 'password1')
           .map((error: any) => error.msg);
         const passsword2FieldErrors = errors
-          .filter((error: any) => error.param === 'password2')
+          .filter((error: any) => error.path === 'password2')
           .map((error: any) => error.msg);
 
         if (emailFieldErrors) setEmailErrors(emailFieldErrors);


### PR DESCRIPTION
## Describe your changes
It seems that we made a change to how we validate input and the error handling logic had to change.

This is what a `validationResult(req)` looks like when it has an error:
```js
Result {
  formatter: [Function: formatter],
  errors: [
    {
      type: 'field',
      value: '22101295@usc.edu.ph',
      msg: 'User with that email already exists.',
      path: 'email',
      location: 'body'
    }
  ]
}
```

Notice the `path` property indicates the type of error. However, in the previous frontend, we were trying to parse the `error.param` instead of `error.path`.

```js
const { response } = err as AxiosError;
const errors = (response as any).data.errors;
const emailFieldErrors = errors.filter((error: any) => error.param === 'email').map((error: any) => error.msg);
const password1FieldErrors = errors.filter((error: any) => error.param === 'password1').map((error: any) => error.msg);
const passsword2FieldErrors = errors.filter((error: any) => error.param === 'password2').map((error: any) => error.msg);
```

I simply changed it to parse the `error.path` instead and the error messages show up now.

## Checklist before requesting a review
- [✔️] I have performed a self-review of my code
- [❌] If it is a core feature, I have added thorough tests.

## Screenshots/Images
![localhost_5173_register](https://github.com/0-BSCode/paper-trail-v2/assets/105530193/90bd74db-31f1-4fd6-bdaf-eb0030b875c4)
