### PR TITLE
[BS] Fix auto logout on expired access token

### DIFF
--- a/client/src/components/ProtectedRoute/index.tsx
+++ b/client/src/components/ProtectedRoute/index.tsx
@@ -7,7 +7,7 @@ import { NotificationModal } from './Notifications';
 import { UserProfileModal } from './UserProfile';
 import WordmarkLogo from '../WordmarkLogo';
 import { LogoutOutlined } from '@ant-design/icons';
-
+import Spinner from '../Spinner';
 const { Header, Content } = Layout;
 
 interface AuthRouteProps {
@@ -34,7 +34,7 @@ const ProtectedRoute = ({ element }: AuthRouteProps): JSX.Element => {
   }, []);
 
   if (loadingAuth) {
-    return <></>;
+    return <Spinner size="lg" />;
   } else {
     if (isAuthenticated)
       return (

--- a/client/src/pages/login/index.tsx
+++ b/client/src/pages/login/index.tsx
@@ -46,9 +46,12 @@ const LoginPage = (): JSX.Element => {
 
     setLoading(true);
     try {
+      // TODO: JWT pair generated here are overriden automatically
+      // due to redirecting to a protected route
       const response = await AuthService.login({ email, password });
       const { accessToken: newAccessToken, refreshToken: newRefreshToken } = response.data;
-      login(newAccessToken, newRefreshToken);
+      // Don't trigger silent refresh since it's done in protected route already
+      login(newAccessToken, newRefreshToken, false);
       success('Successfully logged in!');
       navigate('/home');
     } catch (err) {


### PR DESCRIPTION
## Describe your changes
- To refresh the access token, we send the refresh token (stored on local storage) to the server. However, the refresh token data on the client is stale. That is, the refresh token stored on local storage IS updated, but the refresh token stored in the `useLocalStorage` hook doesn't reflect the updated token. As a result, an old token is passed to the backend, resulting in an error because that token no longer exists.

## Issue ticket number and link
What issue does this PR reference?

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Screenshots/Images
If applicable, show a couple of screenshots of the changes you've implemented.